### PR TITLE
Convert `InstanceChoiceItem` into a subclass of `ABCHasStrictTraits`

### DIFF
--- a/docs/releases/upcoming/1738.bugfix.rst
+++ b/docs/releases/upcoming/1738.bugfix.rst
@@ -1,1 +1,1 @@
-Convert ``traitsui.instance_choice.InstanceChoiceItem`` into an instance of ``traits.api.ABCHasStrictTraits`` to avoid users from instanciating the object directly.
+Convert ``traitsui.instance_choice.InstanceChoiceItem`` into an instance of ``traits.api.ABCHasStrictTraits`` to avoid users from instantiating the object directly.

--- a/docs/releases/upcoming/1738.bugfix.rst
+++ b/docs/releases/upcoming/1738.bugfix.rst
@@ -1,0 +1,1 @@
+Convert ``traitsui.instance_choice.InstanceChoiceItem`` into an instance of ``traits.api.ABCHasStrictTraits`` to avoid users from instanciating the object directly.

--- a/traitsui/instance_choice.py
+++ b/traitsui/instance_choice.py
@@ -12,6 +12,8 @@
     instance editor factory classes.
 """
 
+from abc import abstractmethod
+
 from traits.api import HasPrivateTraits, Str, Any, Dict, Tuple, Callable, Bool
 
 from .ui_traits import AView
@@ -19,7 +21,7 @@ from .ui_traits import AView
 from .helper import user_name_for
 
 
-class InstanceChoiceItem(HasPrivateTraits):
+class InstanceChoiceItem(ABCHasStrictTraits):
 
     # -------------------------------------------------------------------------
     #  Trait definitions:
@@ -43,16 +45,18 @@ class InstanceChoiceItem(HasPrivateTraits):
         """ Returns the view associated with the object.
         """
         return self.view
-
+    
+    @abstractmethod
     def get_object(self):
         """ Returns the object associated with the item.
         """
-        raise NotImplementedError
-
+        pass
+    
+    @abstractmethod
     def is_compatible(self, object):
         """ Indicates whether a specified object is compatible with the item.
         """
-        raise NotImplementedError
+        pass
 
     def is_selectable(self):
         """ Indicates whether the item can be selected by the user.

--- a/traitsui/instance_choice.py
+++ b/traitsui/instance_choice.py
@@ -14,7 +14,13 @@
 
 from abc import abstractmethod
 
-from traits.api import ABCHasStrictTraits, Str, Any, Dict, Tuple, Callable, Bool
+from traits.api import (ABCHasStrictTraits,
+                        Str,
+                        Any,
+                        Dict,
+                        Tuple,
+                        Callable,
+                        Bool)
 
 from .ui_traits import AView
 
@@ -45,13 +51,13 @@ class InstanceChoiceItem(ABCHasStrictTraits):
         """ Returns the view associated with the object.
         """
         return self.view
-    
+
     @abstractmethod
     def get_object(self):
         """ Returns the object associated with the item.
         """
         pass
-    
+
     @abstractmethod
     def is_compatible(self, object):
         """ Indicates whether a specified object is compatible with the item.

--- a/traitsui/instance_choice.py
+++ b/traitsui/instance_choice.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 
-from traits.api import HasPrivateTraits, Str, Any, Dict, Tuple, Callable, Bool
+from traits.api import ABCHasStrictTraits, Str, Any, Dict, Tuple, Callable, Bool
 
 from .ui_traits import AView
 


### PR DESCRIPTION
This avoids some issues when instanciating "InstanceChoiceItem", which is incorrect.


**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)